### PR TITLE
Mention use_makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ require("nvim-treesitter.parsers").get_parser_configs().just = {
     url = "https://github.com/IndianBoy42/tree-sitter-just", -- local path or git repo
     files = { "src/parser.c", "src/scanner.cc" },
     branch = "main",
+    -- use_makefile = true -- this may be necessary on MacOS (try if you see compiler errors)
   },
   maintainers = { "@IndianBoy42" },
 }


### PR DESCRIPTION
Hi, thanks for making this plugin :)

I spent a few hours this weekend getting this to compile. In the end, I needed `-std=c++14` / `-std=c++11` to be added to the `gcc` / `g++` /... command invoked by treesitter.

I could do that for `tree-sitter generate/test` by setting `CXX='g++ -std=c++14'`, but the only way to get this behavior with `:TSInstall` was to add `use_makefile=true` as in this PR. (Apparently `nvim-treesitter` ships with a makefile that sets some of these compiler flags for us, although it doesn't seem to be well-documented).

thanks again for this sweet plugin!