### PR TITLE
Update readme tree-sitter integration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can also add the parser manually using (This is similar to what is done in `
 require("nvim-treesitter.parsers").get_parser_configs().just = {
   install_info = {
     url = "https://github.com/IndianBoy42/tree-sitter-just", -- local path or git repo
-    files = { "src/parser.c", "src/scanner.cc" },
+    files = { "src/parser.c", "src/scanner.c" },
     branch = "main",
     -- use_makefile = true -- this may be necessary on MacOS (try if you see compiler errors)
   },


### PR DESCRIPTION
scanner.cc has been moved to scanner.c, so i updated the instructions accordingly