### PR TITLE
Still diff files that show up as binary but are text

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    branches: [main]
 
 env:
   RUST_BACKTRACE: 1

--- a/justfile
+++ b/justfile
@@ -288,7 +288,7 @@ ci-validate-generated-files exit-code="1":
 	just {{ verbose_flag }} gen
 
 	failed=false
-	git diff ci-tmp-pre-updates --exit-code || failed=true
+	git diff ci-tmp-pre-updates --text --exit-code || failed=true
 	git tag -d ci-tmp-pre-updates
 
 	if ! [ "$failed" = "false" ]; then


### PR DESCRIPTION
CI currently says "Binary files a/src/node-types.json and b/src/node-types.json differ", but we would like some more useful information here.