### PR TITLE
Handle macos SDK in the justfile `include_args`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -37,3 +37,7 @@ indent_size = 8
 [Makefile]
 indent_style = tab
 indent_size = 8
+
+[justfile]
+indent_style = tab
+indent_size = 4

--- a/justfile
+++ b/justfile
@@ -18,9 +18,9 @@ just_branch := "master"
 just_sha := "f5bdffda344daca6c791303e4bb2006ee5a0b144" # 1.35.0
 
 include_args := "-Isrc/ -I" + ts_path + "/lib/include -Inode_modules/nan" + if os() == "macos" {
-" -I" +  `xcrun --sdk macosx --show-sdk-path` + "/usr/include/"
+    " -I" +  `xcrun --sdk macosx --show-sdk-path` + "/usr/include/"
 } else {
-""
+    ""
 }
 general_cflags := "-Wall -Werror --pedantic -Wno-format-pedantic"
 

--- a/justfile
+++ b/justfile
@@ -78,8 +78,6 @@ _check_installed +dep:
 setup *npm-args:
 	#!/bin/sh
 	set -eau
-
-
 	just _check_installed npm cargo clang clang-tidy clang-format kk
 
 	if which npm > /dev/null; then


### PR DESCRIPTION
`just lint` would return missing header errors for macOS making debugging tricky:
```
checking file src/scanner.c
5 warnings and 1 error generated.
Error while processing /Users/mkatychev/Documents/tree-sitter/just/src/scanner.c.
./tree_sitter/parser.h:10:10: error: 'stdlib.h' file not found [clang-diagnostic-error]
#include <stdlib.h>
         ^~~~~~~~~~
```

Added conditional to `include_args` for handling `CPATH` to `stdlib.h`:
https://github.com/IndianBoy42/tree-sitter-just/blob/59f661ce4187dee72a5864490e57d185dc727484/justfile#L20-L24

dependency checker now own just command:
https://github.com/IndianBoy42/tree-sitter-just/blob/59f661ce4187dee72a5864490e57d185dc727484/justfile#L57-L75

Added `justfile` to `.editorconfig`:
https://github.com/IndianBoy42/tree-sitter-just/blob/59f661ce4187dee72a5864490e57d185dc727484/.editorconfig#L41-L43