### PR TITLE
Add missing attributes to grammar

### DIFF
--- a/queries-flavored/helix/highlights.scm
+++ b/queries-flavored/helix/highlights.scm
@@ -141,14 +141,18 @@
     "group"
     "linux"
     "macos"
+    "metadata"
     "no-cd"
     "no-exit-message"
     "no-quiet"
+    "openbsd"
+    "parallel"
     "positional-arguments"
     "private"
     "script"
     "unix"
-    "windows"))
+    "windows"
+    "working-directory"))
 
 ; Numbers are part of the syntax tree, even if disallowed
 (numeric_error) @error

--- a/queries-flavored/lapce/highlights.scm
+++ b/queries-flavored/lapce/highlights.scm
@@ -141,14 +141,18 @@
     "group"
     "linux"
     "macos"
+    "metadata"
     "no-cd"
     "no-exit-message"
     "no-quiet"
+    "openbsd"
+    "parallel"
     "positional-arguments"
     "private"
     "script"
     "unix"
-    "windows"))
+    "windows"
+    "working-directory"))
 
 ; Numbers are part of the syntax tree, even if disallowed
 (numeric_error) @error

--- a/queries-flavored/zed/highlights.scm
+++ b/queries-flavored/zed/highlights.scm
@@ -141,14 +141,18 @@
     "group"
     "linux"
     "macos"
+    "metadata"
     "no-cd"
     "no-exit-message"
     "no-quiet"
+    "openbsd"
+    "parallel"
     "positional-arguments"
     "private"
     "script"
     "unix"
-    "windows"))
+    "windows"
+    "working-directory"))
 
 ; Numbers are part of the syntax tree, even if disallowed
 (numeric_error) @error

--- a/queries-src/highlights.scm
+++ b/queries-src/highlights.scm
@@ -139,14 +139,18 @@
     "group"
     "linux"
     "macos"
+    "metadata"
     "no-cd"
     "no-exit-message"
     "no-quiet"
+    "openbsd"
+    "parallel"
     "positional-arguments"
     "private"
     "script"
     "unix"
-    "windows"))
+    "windows"
+    "working-directory"))
 
 ; Numbers are part of the syntax tree, even if disallowed
 (numeric_error) @error

--- a/queries/just/highlights.scm
+++ b/queries/just/highlights.scm
@@ -141,14 +141,18 @@
     "group"
     "linux"
     "macos"
+    "metadata"
     "no-cd"
     "no-exit-message"
     "no-quiet"
+    "openbsd"
+    "parallel"
     "positional-arguments"
     "private"
     "script"
     "unix"
-    "windows"))
+    "windows"
+    "working-directory"))
 
 ; Numbers are part of the syntax tree, even if disallowed
 (numeric_error) @error


### PR DESCRIPTION
`openbsd` and `working-directory` were added in just 1.38, while `metadata` and `parallel` just landed in 1.42, cf. https://just.systems/man/en/attributes.html#attributes